### PR TITLE
Remove unnecessary import causing build failure on Windows

### DIFF
--- a/src/swapvec.rs
+++ b/src/swapvec.rs
@@ -9,9 +9,6 @@ use std::{
 #[cfg(any(unix, target_os = "wasi"))]
 use std::os::unix::io::AsRawFd;
 
-#[cfg(not(any(unix, target_os = "wasi")))]
-use std::os::fd::AsRawFd;
-
 use serde::{Deserialize, Serialize};
 
 use crate::{error::SwapVecError, swapveciter::SwapVecIter};


### PR DESCRIPTION
This PR fixes builds on Windows. 

The import isn't necessary since we don't use any sort of file descriptor for builds that aren't Unix or WASI. 

![image](https://user-images.githubusercontent.com/19354877/233811052-715e7af1-809e-4921-9a49-5b6e27b0742b.png)
