### PR TITLE
Establish windows check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,5 +27,15 @@ jobs:
       run: cargo test --verbose
     - name: Run lint
       run: cargo clippy
-    - name: Check Windows
-      run: cargo check --target x86_64-pc-windows-msvc
+
+  windows-check:
+    runs-on: self-hosted
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          target: x86_64-pc-windows-msvc
+          toolchain: stable
+          override: true
+      - uses: actions/checkout@v2
+      - name: Check Windows
+        run: cargo check --target x86_64-pc-windows-msvc


### PR DESCRIPTION
Avoid "Could not compile on windows" Issues by accidentally merging unix only code.